### PR TITLE
Replace HTMLParser dependency with SwiftText's HTMLParser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    name: macOS · BrickCore build & test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Versions
+        run: |
+          swift --version
+          xcodebuild -version
+
+      # swift build/test target the host (macOS) and cover the cross-platform
+      # BrickCore package. The 35 Swift Testing tests run here.
+      - name: Build BrickCore (macOS)
+        run: swift build
+
+      - name: Test BrickCore (macOS)
+        run: swift test
+
+  ios:
+    name: iOS · App build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Versions
+        run: xcodebuild -version
+
+      # The SwiftLEGO app target is iOS-only (deployment target 26.0). Building
+      # it for the simulator also compiles BrickCore for iOS. A generic
+      # destination only needs the iOS SDK, not a specific booted simulator.
+      - name: Build app (iOS Simulator)
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project SwiftLEGO.xcodeproj \
+            -scheme SwiftLEGO \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipMacroValidation \
+            CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: macOS · BrickCore build & test
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -39,7 +39,7 @@ jobs:
     name: iOS · App build
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,40 @@
 {
-  "originHash" : "f3d4790e64f0b7a776b7f0ba6b6ba413c8313522f6c7dff8c1c69b8dc062c1a7",
+  "originHash" : "3308e57208779948063f4215ef268055928697c4cbd16673dc11bcc1622c3661",
   "pins" : [
     {
-      "identity" : "htmlparser",
+      "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/odrobnik/HTMLParser.git",
+      "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "branch" : "main",
-        "revision" : "42be6657022b56cc5827b2589cd9d58efc48b8cf"
+        "revision" : "ca37474853a4b5f59a22c74bfdd449b1f6bc4cc2",
+        "version" : "1.8.1"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown.git",
+      "state" : {
+        "revision" : "3c6f9523da3a1ec2fd829673e472d95b8097a3b8",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swifttext",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Cocoanetics/SwiftText.git",
+      "state" : {
+        "revision" : "d095c12420826fe28e67fd1b3f6baa32e4606a80",
+        "version" : "1.1.9"
       }
     },
     {
@@ -17,6 +44,15 @@
       "state" : {
         "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
         "version" : "0.17.1"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,14 +15,14 @@ let package = Package(
 		)
 	],
 	dependencies: [
-		.package(url: "https://github.com/odrobnik/HTMLParser.git", branch: "main"),
+		.package(url: "https://github.com/Cocoanetics/SwiftText.git", from: "1.1.9"),
 		.package(url: "https://github.com/CoreOffice/XMLCoder.git", from: "0.17.1")
 	],
 	targets: [
 		.target(
 			name: "BrickCore",
 			dependencies: [
-				"HTMLParser",
+				.product(name: "SwiftTextHTML", package: "SwiftText"),
 				"XMLCoder"
 			],
 			path: "Sources/BrickCore"

--- a/Sources/BrickCore/Scraper/DomBuilder.swift
+++ b/Sources/BrickCore/Scraper/DomBuilder.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import HTMLParser
+import SwiftTextHTML
 
 public final class DomBuilder
 {
@@ -35,8 +35,8 @@ public final class DomBuilder
 	
 	private func parseHTML(_ html: Data) async throws {
 		let parser = HTMLParser(data: html, encoding: .utf8, options: [.noWarning, .noError, .noNet, .recover])
-		
-		for try await event in parser.parse() {
+
+		for await event in parser.parseEvents() {
 			switch event {
 				case .startElement(let elementName, let attributes):
 					handleStartElement(elementName, attributes: attributes)
@@ -90,6 +90,11 @@ public final class DomBuilder
 	}
 	
 	private func handleCharacters(_ string: String) {
+		// SwiftText's parser can flush accumulated text at structural boundaries
+		// (e.g. trailing whitespace after the root element closes) when no element
+		// is open. Such text has nowhere to attach, so ignore it.
+		guard currentElement != nil else { return }
+
 		let isWhiteSpace = string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 		
 		if (["pre", "code"].contains(currentElement.name))

--- a/SwiftLEGO.xcodeproj/project.pbxproj
+++ b/SwiftLEGO.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A706E0F02EB24E4A008E98D6 /* BrickCore in Frameworks */ = {isa = PBXBuildFile; productRef = A706E0EF2EB24E4A008E98D6 /* BrickCore */; };
-		A7AB6DDF2E945E6300C813E2 /* HTMLParser in Frameworks */ = {isa = PBXBuildFile; productRef = FEEDBEEFCAFEDADA12345678 /* HTMLParser */; };
+		A7AB6DDF2E945E6300C813E2 /* SwiftTextHTML in Frameworks */ = {isa = PBXBuildFile; productRef = FEEDBEEFCAFEDADA12345678 /* SwiftTextHTML */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,7 +34,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A7AB6DDF2E945E6300C813E2 /* HTMLParser in Frameworks */,
+				A7AB6DDF2E945E6300C813E2 /* SwiftTextHTML in Frameworks */,
 				A706E0F02EB24E4A008E98D6 /* BrickCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -87,7 +87,7 @@
 			);
 			name = SwiftLEGO;
 			packageProductDependencies = (
-				FEEDBEEFCAFEDADA12345678 /* HTMLParser */,
+				FEEDBEEFCAFEDADA12345678 /* SwiftTextHTML */,
 				A706E0EF2EB24E4A008E98D6 /* BrickCore */,
 			);
 			productName = SwiftLEGO;
@@ -119,7 +119,7 @@
 			);
 			mainGroup = 4b9c990f617d4737865d90dc;
 			packageReferences = (
-				DADADA00A1B2C3D4E5F60708 /* XCRemoteSwiftPackageReference "HTMLParser" */,
+				DADADA00A1B2C3D4E5F60708 /* XCRemoteSwiftPackageReference "SwiftText" */,
 				A706E0EE2EB24E4A008E98D6 /* XCLocalSwiftPackageReference "../SwiftLEGO" */,
 			);
 			productRefGroup = 39cdcbe6fa9b4cec8e34ec53 /* Products */;
@@ -154,7 +154,7 @@
 /* Begin PBXTargetDependency section */
 		A7AB6DE12E94638A00C813E2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = A7AB6DE02E94638A00C813E2 /* HTMLParser */;
+			productRef = A7AB6DE02E94638A00C813E2 /* SwiftTextHTML */;
 		};
 /* End PBXTargetDependency section */
 
@@ -407,12 +407,12 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		DADADA00A1B2C3D4E5F60708 /* XCRemoteSwiftPackageReference "HTMLParser" */ = {
+		DADADA00A1B2C3D4E5F60708 /* XCRemoteSwiftPackageReference "SwiftText" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/odrobnik/HTMLParser.git";
+			repositoryURL = "https://github.com/Cocoanetics/SwiftText.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.9;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -422,15 +422,15 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = BrickCore;
 		};
-		A7AB6DE02E94638A00C813E2 /* HTMLParser */ = {
+		A7AB6DE02E94638A00C813E2 /* SwiftTextHTML */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = DADADA00A1B2C3D4E5F60708 /* XCRemoteSwiftPackageReference "HTMLParser" */;
-			productName = HTMLParser;
+			package = DADADA00A1B2C3D4E5F60708 /* XCRemoteSwiftPackageReference "SwiftText" */;
+			productName = SwiftTextHTML;
 		};
-		FEEDBEEFCAFEDADA12345678 /* HTMLParser */ = {
+		FEEDBEEFCAFEDADA12345678 /* SwiftTextHTML */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = DADADA00A1B2C3D4E5F60708 /* XCRemoteSwiftPackageReference "HTMLParser" */;
-			productName = HTMLParser;
+			package = DADADA00A1B2C3D4E5F60708 /* XCRemoteSwiftPackageReference "SwiftText" */;
+			productName = SwiftTextHTML;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/SwiftLEGO.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftLEGO.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,40 @@
 {
-  "originHash" : "96b6bf164f06bae430addfc57789d147acb6239598c560806b257a40dbb732b9",
+  "originHash" : "3308e57208779948063f4215ef268055928697c4cbd16673dc11bcc1622c3661",
   "pins" : [
     {
-      "identity" : "htmlparser",
+      "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/odrobnik/HTMLParser.git",
+      "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "branch" : "main",
-        "revision" : "42be6657022b56cc5827b2589cd9d58efc48b8cf"
+        "revision" : "ca37474853a4b5f59a22c74bfdd449b1f6bc4cc2",
+        "version" : "1.8.1"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown.git",
+      "state" : {
+        "revision" : "3c6f9523da3a1ec2fd829673e472d95b8097a3b8",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swifttext",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Cocoanetics/SwiftText.git",
+      "state" : {
+        "revision" : "d095c12420826fe28e67fd1b3f6baa32e4606a80",
+        "version" : "1.1.9"
       }
     },
     {
@@ -17,6 +44,15 @@
       "state" : {
         "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
         "version" : "0.17.1"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],


### PR DESCRIPTION
## What

Replaces the `odrobnik/HTMLParser` dependency with the more modern HTMLParser module in **SwiftText** (`github.com/Cocoanetics/SwiftText`, pinned `from: 1.1.9`). SwiftText doesn't ship `HTMLParser` as a standalone product, so it's consumed via the **`SwiftTextHTML`** product, which `@_exported import HTMLParser`.

## Why

Move the scraper onto the maintained, cross-platform SwiftText HTML stack (libxml2-backed, pure-Swift wrapper) instead of the standalone legacy package.

## Changes

- **`Package.swift`** — dependency `odrobnik/HTMLParser` → `Cocoanetics/SwiftText`; BrickCore target dep `"HTMLParser"` → `.product(name: "SwiftTextHTML", package: "SwiftText")`.
- **`DomBuilder.swift`**
  - `import HTMLParser` → `import SwiftTextHTML`. The local `DOMElement`/`DOMText` types live in the `BrickCore` module, so they shadow SwiftTextHTML's same-named types (well-defined; no ambiguity).
  - `parser.parse()` (throwing `AsyncThrowingStream`) → `parser.parseEvents()` (non-throwing `AsyncStream`); the `for try await` loop becomes `for await`.
  - Added `guard currentElement != nil` in `handleCharacters`. **Behavioral difference:** SwiftText accumulates text and flushes it at structural boundaries (including after the root element closes), so the handler can now receive character events with no open element — which crashed on a force-unwrap. Such text has nowhere to attach and is ignored.
- **`SwiftLEGO.xcodeproj/project.pbxproj`** — the app target carried a redundant *direct* reference to the old HTMLParser package (the app's own source never imports it; it gets parsing via BrickCore). Migrated that reference to SwiftText/`SwiftTextHTML` so nothing points at the old repo.
- Regenerated both `Package.resolved` files (SPM + Xcode workspace).

## Reviewer notes

- The `parseHTML`/`init` signatures stay `async throws` even though the new stream is non-throwing, keeping the 3 call sites unchanged. `.recover` + `.noError`/`.noWarning` options mean parse errors are best-effort/ignored, matching prior behavior.
- Verified: `swift build`, **35/35 BrickCore tests** (incl. the HTML-fixture and inventory tests that surfaced the nil-character crash), and a **full Xcode iOS app build (`BUILD SUCCEEDED`)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)