### PR TITLE
Update SwiftText to 1.2.0 and harden the BrickLink fetch path

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3308e57208779948063f4215ef268055928697c4cbd16673dc11bcc1622c3661",
+  "originHash" : "4de44190d8d97022aab07590d7c3642ffe186579197f9a334fa0c528fca7d0cf",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftText.git",
       "state" : {
-        "revision" : "d095c12420826fe28e67fd1b3f6baa32e4606a80",
-        "version" : "1.1.9"
+        "revision" : "3076cdfd22f82b0ec4adf3856b83dd269d15b039",
+        "version" : "1.2.0"
       }
     },
     {
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
         "version" : "0.17.1"
+      }
+    },
+    {
+      "identity" : "xmlkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Cocoanetics/XMLKit.git",
+      "state" : {
+        "revision" : "92f0051ab9f2d570647b8b76f688b53bdfc1bf06",
+        "version" : "1.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 		)
 	],
 	dependencies: [
-		.package(url: "https://github.com/Cocoanetics/SwiftText.git", from: "1.1.9"),
+		.package(url: "https://github.com/Cocoanetics/SwiftText.git", from: "1.2.0"),
 		.package(url: "https://github.com/CoreOffice/XMLCoder.git", from: "0.17.1")
 	],
 	targets: [

--- a/Sources/BrickCore/BrickLinkInventoryService.swift
+++ b/Sources/BrickCore/BrickLinkInventoryService.swift
@@ -17,6 +17,10 @@ public final class BrickLinkInventoryService {
 	/// Guards against an item whose inventory transitively contains itself.
 	private static let maximumInventoryDepth = 4
 
+	/// Ceiling on requests in flight, so importing a large set stays a polite
+	/// trickle rather than a burst BrickLink would throttle.
+	private static let maximumConcurrentRequests = 6
+
 	public init() {}
 
 	public func fetchInventory(for setNumber: String) async throws -> BrickLinkInventory {
@@ -69,19 +73,24 @@ public final class BrickLinkInventoryService {
 	) async throws -> [BrickLinkPart] {
 		guard !rows.isEmpty else { return [] }
 
-		return try await withThrowingTaskGroup(of: (Int, BrickLinkPart).self) { group in
-			for (index, row) in rows.enumerated() {
-				group.addTask {
-					(index, try await self.part(from: row, depth: depth))
-				}
-			}
+		// Most rows are plain parts that need no request at all; building those
+		// inline keeps the concurrent window for the few that have subparts.
+		let fetchable = rows.indices.filter {
+			rows[$0].needsInventoryFetch(depth: depth, maximumDepth: Self.maximumInventoryDepth)
+		}
 
-			var ordered: [BrickLinkPart?] = Array(repeating: nil, count: rows.count)
-			for try await (index, part) in group {
-				ordered[index] = part
-			}
+		guard !fetchable.isEmpty else {
+			return rows.map { makePart(from: $0, inventoryURL: nil, subparts: []) }
+		}
 
-			return ordered.compactMap { $0 }
+		let enriched = try await mapConcurrently(fetchable, limit: Self.maximumConcurrentRequests) { index in
+			(index, try await self.part(from: rows[index], depth: depth))
+		}
+
+		var byIndex = Dictionary(uniqueKeysWithValues: enriched)
+
+		return rows.indices.map { index in
+			byIndex.removeValue(forKey: index) ?? makePart(from: rows[index], inventoryURL: nil, subparts: [])
 		}
 	}
 
@@ -89,9 +98,8 @@ public final class BrickLinkInventoryService {
 		var subparts: [BrickLinkPart] = []
 		var inventoryURL: URL?
 
-		if row.hasOwnInventory,
-		   let idItem = row.idItem,
-		   depth < Self.maximumInventoryDepth {
+		if row.needsInventoryFetch(depth: depth, maximumDepth: Self.maximumInventoryDepth),
+		   let idItem = row.idItem {
 			inventoryURL = BrickLinkInventoryTable.url(idItem: idItem, itemNumber: row.itemNumber)
 
 			// A missing sub-inventory should not fail the whole import.
@@ -130,21 +138,8 @@ public final class BrickLinkInventoryService {
 	private func enrichedMinifigures(
 		from rows: [BrickLinkInventoryTable.ItemRow]
 	) async throws -> [BrickLinkMinifigure] {
-		guard !rows.isEmpty else { return [] }
-
-		return try await withThrowingTaskGroup(of: (Int, BrickLinkMinifigure).self) { group in
-			for (index, row) in rows.enumerated() {
-				group.addTask {
-					(index, try await self.minifigure(from: row))
-				}
-			}
-
-			var ordered: [BrickLinkMinifigure?] = Array(repeating: nil, count: rows.count)
-			for try await (index, minifigure) in group {
-				ordered[index] = minifigure
-			}
-
-			return ordered.compactMap { $0 }
+		try await mapConcurrently(rows, limit: Self.maximumConcurrentRequests) { row in
+			try await self.minifigure(from: row)
 		}
 	}
 

--- a/Sources/BrickCore/BrickLinkInventoryService.swift
+++ b/Sources/BrickCore/BrickLinkInventoryService.swift
@@ -17,9 +17,11 @@ public final class BrickLinkInventoryService {
 	/// Guards against an item whose inventory transitively contains itself.
 	private static let maximumInventoryDepth = 4
 
-	/// Ceiling on requests in flight, so importing a large set stays a polite
-	/// trickle rather than a burst BrickLink would throttle.
-	private static let maximumConcurrentRequests = 6
+	/// How many rows are walked at once. This bounds task creation only — an
+	/// import fans out as a tree, so these windows nest and multiply. The ceiling
+	/// that actually protects BrickLink is `HTMLFetcher.maximumConcurrentRequests`,
+	/// which every request shares.
+	private static let maximumConcurrentRows = 6
 
 	public init() {}
 
@@ -83,7 +85,7 @@ public final class BrickLinkInventoryService {
 			return rows.map { makePart(from: $0, inventoryURL: nil, subparts: []) }
 		}
 
-		let enriched = try await mapConcurrently(fetchable, limit: Self.maximumConcurrentRequests) { index in
+		let enriched = try await mapConcurrently(fetchable, limit: Self.maximumConcurrentRows) { index in
 			(index, try await self.part(from: rows[index], depth: depth))
 		}
 
@@ -138,7 +140,7 @@ public final class BrickLinkInventoryService {
 	private func enrichedMinifigures(
 		from rows: [BrickLinkInventoryTable.ItemRow]
 	) async throws -> [BrickLinkMinifigure] {
-		try await mapConcurrently(rows, limit: Self.maximumConcurrentRequests) { row in
+		try await mapConcurrently(rows, limit: Self.maximumConcurrentRows) { row in
 			try await self.minifigure(from: row)
 		}
 	}

--- a/Sources/BrickCore/Scraper/HTMLFetcher.swift
+++ b/Sources/BrickCore/Scraper/HTMLFetcher.swift
@@ -7,37 +7,119 @@
 
 import Foundation
 
-/// Downloads HTML pages using headers that mimic a normal browser navigation.
+/// Downloads HTML pages using headers that mimic a normal browser navigation,
+/// retrying the failures that are worth retrying.
 ///
 /// `Data(contentsOf:)` sends the default `CFNetwork`/`Darwin` user agent, which
 /// BrickLink's WAF answers with an empty body — the scraper then has nothing to
 /// parse. Supplying a browser user agent and the usual navigation headers gets
-/// real markup back from the catalog and color-guide pages.
+/// real markup back from the catalog pages.
 enum HTMLFetcher
 {
 	/// Safari on macOS, the least surprising identity for a page scrape.
 	static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15"
 
-	static func data(from url: URL) async throws -> Data
+	static let maximumAttempts = 3
+	static let requestTimeout: TimeInterval = 30
+
+	static func data(from url: URL, session: URLSession = .shared) async throws -> Data
 	{
-		let (data, response) = try await URLSession.shared.data(for: request(for: url))
+		var attempt = 1
 
-		guard let http = response as? HTTPURLResponse else
+		while true
 		{
-			return data
-		}
+			do
+			{
+				return try await fetchOnce(url, session: session)
+			}
+			catch is CancellationError
+			{
+				throw CancellationError()
+			}
+			catch
+			{
+				guard attempt < maximumAttempts, Self.isWorthRetrying(error) else
+				{
+					throw error
+				}
 
-		guard (200..<300).contains(http.statusCode) else
+				try await Task.sleep(for: retryDelay(afterAttempt: attempt))
+				attempt += 1
+			}
+		}
+	}
+
+	private static func fetchOnce(_ url: URL, session: URLSession) async throws -> Data
+	{
+		let (data, response) = try await session.data(for: request(for: url))
+
+		if let http = response as? HTTPURLResponse,
+		   !(200..<300).contains(http.statusCode)
 		{
 			throw FetchError.unexpectedStatus(http.statusCode, url)
+		}
+
+		// A bot-protection interstitial answers 200/202 with a page that has no
+		// content of ours in it. Retrying cannot solve a JavaScript challenge, so
+		// say so plainly rather than failing later as "nothing to parse".
+		if looksLikeBotProtection(data)
+		{
+			throw FetchError.blockedByBotProtection(url)
+		}
+
+		guard !data.isEmpty else
+		{
+			throw FetchError.emptyResponse(url)
 		}
 
 		return data
 	}
 
+	private static func looksLikeBotProtection(_ data: Data) -> Bool
+	{
+		// The challenge page is small; a real catalog page never is.
+		guard data.count < 16_384,
+			  let markup = String(data: data, encoding: .utf8) else
+		{
+			return false
+		}
+
+		return markup.contains("awsWafCookieDomainList") || markup.contains("gokuProps")
+	}
+
+	private static func retryDelay(afterAttempt attempt: Int) -> Duration
+	{
+		.milliseconds(500 * (1 << (attempt - 1)))
+	}
+
+	private static func isWorthRetrying(_ error: Error) -> Bool
+	{
+		if let fetchError = error as? FetchError
+		{
+			return fetchError.isWorthRetrying
+		}
+
+		guard let urlError = error as? URLError else { return false }
+
+		switch urlError.code
+		{
+			case .timedOut,
+				 .networkConnectionLost,
+				 .notConnectedToInternet,
+				 .cannotConnectToHost,
+				 .dnsLookupFailed,
+				 .resourceUnavailable:
+				return true
+
+			default:
+				return false
+		}
+	}
+
 	private static func request(for url: URL) -> URLRequest
 	{
 		var request = URLRequest(url: url)
+		request.timeoutInterval = requestTimeout
 
 		request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
 		request.setValue("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", forHTTPHeaderField: "Accept")
@@ -50,9 +132,28 @@ enum HTMLFetcher
 		return request
 	}
 
-	enum FetchError: LocalizedError
+	enum FetchError: LocalizedError, Equatable
 	{
 		case unexpectedStatus(Int, URL)
+		case emptyResponse(URL)
+		case blockedByBotProtection(URL)
+
+		/// Rate limiting and server faults pass with time; a challenge or a 404
+		/// will answer the same way however often it is asked.
+		var isWorthRetrying: Bool
+		{
+			switch self
+			{
+				case .unexpectedStatus(let status, _):
+					return status == 408 || status == 429 || (500..<600).contains(status)
+
+				case .emptyResponse:
+					return true
+
+				case .blockedByBotProtection:
+					return false
+			}
+		}
 
 		var errorDescription: String?
 		{
@@ -60,6 +161,12 @@ enum HTMLFetcher
 			{
 				case .unexpectedStatus(let status, let url):
 					return "\(url.absoluteString) responded with HTTP \(status)."
+
+				case .emptyResponse(let url):
+					return "\(url.absoluteString) returned an empty response."
+
+				case .blockedByBotProtection(let url):
+					return "BrickLink served a bot-protection challenge for \(url.absoluteString) instead of the page."
 			}
 		}
 	}

--- a/Sources/BrickCore/Scraper/HTMLFetcher.swift
+++ b/Sources/BrickCore/Scraper/HTMLFetcher.swift
@@ -22,6 +22,15 @@ enum HTMLFetcher
 	static let maximumAttempts = 3
 	static let requestTimeout: TimeInterval = 30
 
+	/// Ceiling on requests in flight, shared by every caller.
+	///
+	/// It lives here rather than at the call sites because an import fans out as
+	/// a tree — parts and minifigures walk concurrently, and each minifigure
+	/// walks its own parts — so per-call-site limits would multiply.
+	static let maximumConcurrentRequests = 6
+
+	private static let gate = RequestGate(limit: maximumConcurrentRequests)
+
 	static func data(from url: URL, session: URLSession = .shared) async throws -> Data
 	{
 		var attempt = 1
@@ -51,7 +60,12 @@ enum HTMLFetcher
 
 	private static func fetchOnce(_ url: URL, session: URLSession) async throws -> Data
 	{
-		let (data, response) = try await session.data(for: request(for: url))
+		// The permit covers the round trip only — parsing and retry backoff must
+		// not hold a slot that another request could be using.
+		let request = request(for: url)
+		let (data, response) = try await gate.withPermit {
+			try await session.data(for: request)
+		}
 
 		if let http = response as? HTTPURLResponse,
 		   !(200..<300).contains(http.statusCode)

--- a/Sources/BrickCore/Scraper/RequestGate.swift
+++ b/Sources/BrickCore/Scraper/RequestGate.swift
@@ -1,0 +1,67 @@
+//
+//  RequestGate.swift
+//
+//
+//  A counting semaphore for async callers.
+//
+
+import Foundation
+
+/// Caps how many operations may run at once, across every caller that shares it.
+///
+/// Bounding concurrency at each call site is not enough when the work forms a
+/// tree: importing a set walks parts and minifigures at the same time, and each
+/// minifigure walks its own parts, so per-call-site limits multiply. The remote
+/// server is one shared resource, so the ceiling has to be shared too.
+actor RequestGate
+{
+	private let limit: Int
+	private var active = 0
+	private var waiters: [CheckedContinuation<Void, Never>] = []
+
+	init(limit: Int)
+	{
+		self.limit = max(1, limit)
+	}
+
+	/// Runs `body` once a permit is free, releasing it however `body` ends.
+	func withPermit<T: Sendable>(_ body: @Sendable () async throws -> T) async rethrows -> T
+	{
+		await acquire()
+		defer { release() }
+
+		return try await body()
+	}
+
+	/// Permits currently held. Test seam.
+	var activeCount: Int
+	{
+		active
+	}
+
+	private func acquire() async
+	{
+		guard active >= limit else
+		{
+			active += 1
+			return
+		}
+
+		// Resumed by `release()`, which hands its permit over directly rather
+		// than decrementing — so the count never dips and lets an extra caller in.
+		await withCheckedContinuation { continuation in
+			waiters.append(continuation)
+		}
+	}
+
+	private func release()
+	{
+		guard waiters.isEmpty else
+		{
+			waiters.removeFirst().resume()
+			return
+		}
+
+		active -= 1
+	}
+}

--- a/Sources/BrickCore/Services/BrickLinkInventoryTable.swift
+++ b/Sources/BrickCore/Services/BrickLinkInventoryTable.swift
@@ -27,6 +27,11 @@ struct BrickLinkInventoryTable: Equatable {
 		/// True when the row carries an "(inv)" link, i.e. the item has subparts.
 		let hasOwnInventory: Bool
 		let section: BrickLinkPartSection
+
+		/// Whether reading this row fully costs another request.
+		func needsInventoryFetch(depth: Int, maximumDepth: Int) -> Bool {
+			hasOwnInventory && idItem != nil && depth < maximumDepth
+		}
 	}
 
 	let parts: [ItemRow]

--- a/Sources/BrickCore/Services/ConcurrentMap.swift
+++ b/Sources/BrickCore/Services/ConcurrentMap.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Maps `items` concurrently while keeping at most `limit` transforms in flight,
+/// returning results in the order of the input.
+///
+/// A set inventory can list hundreds of rows, and a plain task group would put a
+/// request for every one of them on the wire at once — enough to look like an
+/// attack and get throttled. This keeps a sliding window instead: the group is
+/// primed with `limit` tasks and starts another only as one finishes.
+func mapConcurrently<Element: Sendable, Transformed: Sendable>(
+	_ items: [Element],
+	limit: Int,
+	_ transform: @escaping @Sendable (Element) async throws -> Transformed
+) async throws -> [Transformed] {
+	guard !items.isEmpty else { return [] }
+
+	let limit = max(1, limit)
+	var results: [Transformed?] = Array(repeating: nil, count: items.count)
+
+	try await withThrowingTaskGroup(of: (Int, Transformed).self) { group in
+		var next = 0
+
+		while next < min(limit, items.count) {
+			let index = next
+			group.addTask { (index, try await transform(items[index])) }
+			next += 1
+		}
+
+		while let (index, transformed) = try await group.next() {
+			results[index] = transformed
+
+			guard next < items.count else { continue }
+
+			let index = next
+			group.addTask { (index, try await transform(items[index])) }
+			next += 1
+		}
+	}
+
+	return results.compactMap { $0 }
+}

--- a/SwiftLEGO.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftLEGO.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3308e57208779948063f4215ef268055928697c4cbd16673dc11bcc1622c3661",
+  "originHash" : "8ea760de8c3d6fe2531cb5b8a80ef80de83b7d7d3992358a4750260b1e03b2db",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftText.git",
       "state" : {
-        "revision" : "d095c12420826fe28e67fd1b3f6baa32e4606a80",
-        "version" : "1.1.9"
+        "revision" : "3076cdfd22f82b0ec4adf3856b83dd269d15b039",
+        "version" : "1.2.0"
       }
     },
     {
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
         "version" : "0.17.1"
+      }
+    },
+    {
+      "identity" : "xmlkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Cocoanetics/XMLKit.git",
+      "state" : {
+        "revision" : "92f0051ab9f2d570647b8b76f688b53bdfc1bf06",
+        "version" : "1.0.1"
       }
     },
     {

--- a/Tests/BrickCoreTests/ConcurrentMapTests.swift
+++ b/Tests/BrickCoreTests/ConcurrentMapTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import BrickCore
+
+struct ConcurrentMapTests {
+
+	/// Tracks how many transforms overlapped.
+	private actor PeakCounter {
+		private var active = 0
+		private(set) var peak = 0
+
+		func enter() {
+			active += 1
+			peak = max(peak, active)
+		}
+
+		func leave() {
+			active -= 1
+		}
+	}
+
+	@Test
+	func resultsKeepInputOrder() async throws {
+		let input = Array(1...50)
+
+		let doubled = try await mapConcurrently(input, limit: 8) { value in
+			// Reversing the sleep order would surface any ordering bug.
+			try await Task.sleep(for: .milliseconds(value % 5))
+			return value * 2
+		}
+
+		#expect(doubled == input.map { $0 * 2 })
+	}
+
+	@Test
+	func concurrencyStaysWithinTheLimit() async throws {
+		let counter = PeakCounter()
+
+		_ = try await mapConcurrently(Array(1...40), limit: 4) { _ in
+			await counter.enter()
+			try await Task.sleep(for: .milliseconds(5))
+			await counter.leave()
+			return 0
+		}
+
+		let peak = await counter.peak
+		#expect(peak <= 4, "Expected at most 4 concurrent transforms, saw \(peak).")
+	}
+
+	@Test
+	func emptyInputDoesNoWork() async throws {
+		let results = try await mapConcurrently([Int](), limit: 4) { _ in
+			Issue.record("Transform should not run for an empty input.")
+			return 0
+		}
+
+		#expect(results.isEmpty)
+	}
+
+	@Test
+	func aThrowingTransformPropagates() async throws {
+		struct Boom: Error {}
+
+		await #expect(throws: Boom.self) {
+			try await mapConcurrently(Array(1...20), limit: 4) { value in
+				if value == 7 { throw Boom() }
+				return value
+			}
+		}
+	}
+
+	@Test
+	func limitBelowOneIsTreatedAsSerial() async throws {
+		let results = try await mapConcurrently([1, 2, 3], limit: 0) { $0 + 1 }
+
+		#expect(results == [2, 3, 4])
+	}
+}

--- a/Tests/BrickCoreTests/HTMLFetcherTests.swift
+++ b/Tests/BrickCoreTests/HTMLFetcherTests.swift
@@ -82,6 +82,46 @@ struct HTMLFetcherTests {
 		#expect(StubURLProtocol.requestCount == 1)
 	}
 
+	/// The cap has to hold across the whole import, not per call site: parts and
+	/// minifigures are walked concurrently and each minifigure walks its own
+	/// parts, so limits applied at each fan-out point would multiply.
+	@Test
+	func concurrentRequestsShareOneCeiling() async throws {
+		StubURLProtocol.reset(
+			with: [.html("<html><body>ok</body></html>")],
+			responseDelay: .milliseconds(20)
+		)
+
+		let session = StubURLProtocol.makeSession()
+
+		// Nested fan-out: several groups, each fetching several pages.
+		try await withThrowingTaskGroup(of: Void.self) { outer in
+			for group in 0..<5 {
+				outer.addTask {
+					try await withThrowingTaskGroup(of: Void.self) { inner in
+						for page in 0..<6 {
+							inner.addTask {
+								let url = URL(string: "https://www.bricklink.com/p/\(group)-\(page)")!
+								_ = try await HTMLFetcher.data(from: url, session: session)
+							}
+						}
+						try await inner.waitForAll()
+					}
+				}
+			}
+			try await outer.waitForAll()
+		}
+
+		#expect(StubURLProtocol.requestCount == 30)
+		#expect(
+			StubURLProtocol.peakConcurrentRequests <= HTMLFetcher.maximumConcurrentRequests,
+			"""
+			Expected at most \(HTMLFetcher.maximumConcurrentRequests) requests in flight, \
+			saw \(StubURLProtocol.peakConcurrentRequests).
+			"""
+		)
+	}
+
 	@Test
 	func retryClassificationMatchesStatusSemantics() {
 		#expect(HTMLFetcher.FetchError.unexpectedStatus(429, Self.url).isWorthRetrying)

--- a/Tests/BrickCoreTests/HTMLFetcherTests.swift
+++ b/Tests/BrickCoreTests/HTMLFetcherTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import BrickCore
+
+/// Serialized because `StubURLProtocol` queues its responses globally.
+@Suite(.serialized)
+struct HTMLFetcherTests {
+
+	private static let url = URL(string: "https://www.bricklink.com/v2/catalog/catalogitem.page?S=43245-1")!
+
+	/// The interstitial BrickLink serves in place of catalogItemInv.asp.
+	private static let challengePage = """
+	<!DOCTYPE html><html><head><script>
+	window.awsWafCookieDomainList = ['www.bricklink.com'];
+	window.gokuProps = { "key": "AQID" };
+	</script></head><body></body></html>
+	"""
+
+	@Test
+	func successfulResponseIsReturned() async throws {
+		StubURLProtocol.reset(with: [.html("<html><body>hello</body></html>")])
+
+		let data = try await HTMLFetcher.data(from: Self.url, session: StubURLProtocol.makeSession())
+
+		#expect(String(decoding: data, as: UTF8.self).contains("hello"))
+		#expect(StubURLProtocol.requestCount == 1)
+	}
+
+	@Test
+	func botProtectionIsReportedAndNotRetried() async throws {
+		StubURLProtocol.reset(with: [.html(Self.challengePage, statusCode: 202)])
+
+		await #expect(throws: HTMLFetcher.FetchError.blockedByBotProtection(Self.url)) {
+			try await HTMLFetcher.data(from: Self.url, session: StubURLProtocol.makeSession())
+		}
+
+		// Retrying cannot solve a JavaScript challenge.
+		#expect(StubURLProtocol.requestCount == 1)
+	}
+
+	@Test
+	func emptyBodyIsAnErrorRatherThanEmptyData() async throws {
+		StubURLProtocol.reset(with: [.init(statusCode: 202, body: Data())])
+
+		await #expect(throws: HTMLFetcher.FetchError.self) {
+			try await HTMLFetcher.data(from: Self.url, session: StubURLProtocol.makeSession())
+		}
+	}
+
+	@Test
+	func transientServerErrorIsRetriedThenSucceeds() async throws {
+		StubURLProtocol.reset(with: [
+			.html("nope", statusCode: 503),
+			.html("<html><body>recovered</body></html>")
+		])
+
+		let data = try await HTMLFetcher.data(from: Self.url, session: StubURLProtocol.makeSession())
+
+		#expect(String(decoding: data, as: UTF8.self).contains("recovered"))
+		#expect(StubURLProtocol.requestCount == 2)
+	}
+
+	@Test
+	func rateLimitIsRetriedUpToTheAttemptLimit() async throws {
+		StubURLProtocol.reset(with: [.html("slow down", statusCode: 429)])
+
+		await #expect(throws: HTMLFetcher.FetchError.self) {
+			try await HTMLFetcher.data(from: Self.url, session: StubURLProtocol.makeSession())
+		}
+
+		#expect(StubURLProtocol.requestCount == HTMLFetcher.maximumAttempts)
+	}
+
+	@Test
+	func clientErrorIsNotRetried() async throws {
+		StubURLProtocol.reset(with: [.html("gone", statusCode: 404)])
+
+		await #expect(throws: HTMLFetcher.FetchError.unexpectedStatus(404, Self.url)) {
+			try await HTMLFetcher.data(from: Self.url, session: StubURLProtocol.makeSession())
+		}
+
+		#expect(StubURLProtocol.requestCount == 1)
+	}
+
+	@Test
+	func retryClassificationMatchesStatusSemantics() {
+		#expect(HTMLFetcher.FetchError.unexpectedStatus(429, Self.url).isWorthRetrying)
+		#expect(HTMLFetcher.FetchError.unexpectedStatus(503, Self.url).isWorthRetrying)
+		#expect(HTMLFetcher.FetchError.unexpectedStatus(408, Self.url).isWorthRetrying)
+		#expect(!HTMLFetcher.FetchError.unexpectedStatus(404, Self.url).isWorthRetrying)
+		#expect(!HTMLFetcher.FetchError.blockedByBotProtection(Self.url).isWorthRetrying)
+		#expect(HTMLFetcher.FetchError.emptyResponse(Self.url).isWorthRetrying)
+	}
+}

--- a/Tests/BrickCoreTests/RequestGateTests.swift
+++ b/Tests/BrickCoreTests/RequestGateTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import BrickCore
+
+struct RequestGateTests {
+
+	private actor PeakCounter {
+		private var active = 0
+		private(set) var peak = 0
+		private(set) var completed = 0
+
+		func enter() {
+			active += 1
+			peak = max(peak, active)
+		}
+
+		func leave() {
+			active -= 1
+			completed += 1
+		}
+	}
+
+	@Test
+	func permitsNeverExceedTheLimit() async throws {
+		let gate = RequestGate(limit: 3)
+		let counter = PeakCounter()
+
+		await withTaskGroup(of: Void.self) { group in
+			for _ in 0..<30 {
+				group.addTask {
+					await gate.withPermit {
+						await counter.enter()
+						try? await Task.sleep(for: .milliseconds(5))
+						await counter.leave()
+					}
+				}
+			}
+		}
+
+		let peak = await counter.peak
+		let completed = await counter.completed
+
+		#expect(peak <= 3, "Expected at most 3 permits, saw \(peak).")
+		#expect(completed == 30)
+	}
+
+	/// A permit handed to a waiter must not also be counted as released, or the
+	/// gate would leak capacity every time it is contended.
+	@Test
+	func permitsAreFullyReturnedAfterContention() async throws {
+		let gate = RequestGate(limit: 2)
+
+		await withTaskGroup(of: Void.self) { group in
+			for _ in 0..<20 {
+				group.addTask {
+					await gate.withPermit {
+						try? await Task.sleep(for: .milliseconds(2))
+					}
+				}
+			}
+		}
+
+		let active = await gate.activeCount
+		#expect(active == 0, "Gate should be idle once every permit is returned, saw \(active).")
+	}
+
+	@Test
+	func aThrowingBodyStillReturnsItsPermit() async throws {
+		struct Boom: Error {}
+
+		let gate = RequestGate(limit: 1)
+
+		await #expect(throws: Boom.self) {
+			try await gate.withPermit { throw Boom() }
+		}
+
+		let active = await gate.activeCount
+		#expect(active == 0)
+
+		// The gate is still usable.
+		let value = await gate.withPermit { 42 }
+		#expect(value == 42)
+	}
+
+	@Test
+	func limitBelowOneStillAdmitsOneCaller() async throws {
+		let gate = RequestGate(limit: 0)
+
+		let value = await gate.withPermit { "ran" }
+
+		#expect(value == "ran")
+	}
+}

--- a/Tests/BrickCoreTests/TestSupport/StubURLProtocol.swift
+++ b/Tests/BrickCoreTests/TestSupport/StubURLProtocol.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Serves canned responses to a `URLSession` so fetch behaviour can be tested
+/// without touching the network.
+final class StubURLProtocol: URLProtocol, @unchecked Sendable {
+	struct Response {
+		let statusCode: Int
+		let body: Data
+
+		init(statusCode: Int = 200, body: Data = Data("<html><body>ok</body></html>".utf8)) {
+			self.statusCode = statusCode
+			self.body = body
+		}
+
+		static func html(_ markup: String, statusCode: Int = 200) -> Response {
+			Response(statusCode: statusCode, body: Data(markup.utf8))
+		}
+	}
+
+	/// Consumed front to back, one per request; the last entry repeats.
+	nonisolated(unsafe) private static var queue: [Response] = []
+	nonisolated(unsafe) private static var recordedRequests = 0
+	private static let lock = NSLock()
+
+	static func reset(with responses: [Response]) {
+		lock.lock()
+		defer { lock.unlock() }
+		queue = responses
+		recordedRequests = 0
+	}
+
+	static var requestCount: Int {
+		lock.lock()
+		defer { lock.unlock() }
+		return recordedRequests
+	}
+
+	private static func nextResponse() -> Response {
+		lock.lock()
+		defer { lock.unlock() }
+		recordedRequests += 1
+
+		if queue.count > 1 {
+			return queue.removeFirst()
+		}
+
+		return queue.first ?? Response()
+	}
+
+	static func makeSession() -> URLSession {
+		let configuration = URLSessionConfiguration.ephemeral
+		configuration.protocolClasses = [StubURLProtocol.self]
+		return URLSession(configuration: configuration)
+	}
+
+	override class func canInit(with request: URLRequest) -> Bool { true }
+
+	override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+	override func startLoading() {
+		let stub = Self.nextResponse()
+		let response = HTTPURLResponse(
+			url: request.url!,
+			statusCode: stub.statusCode,
+			httpVersion: "HTTP/1.1",
+			headerFields: ["Content-Type": "text/html"]
+		)!
+
+		client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+		client?.urlProtocol(self, didLoad: stub.body)
+		client?.urlProtocolDidFinishLoading(self)
+	}
+
+	override func stopLoading() {}
+}

--- a/Tests/BrickCoreTests/TestSupport/StubURLProtocol.swift
+++ b/Tests/BrickCoreTests/TestSupport/StubURLProtocol.swift
@@ -20,19 +20,47 @@ final class StubURLProtocol: URLProtocol, @unchecked Sendable {
 	/// Consumed front to back, one per request; the last entry repeats.
 	nonisolated(unsafe) private static var queue: [Response] = []
 	nonisolated(unsafe) private static var recordedRequests = 0
+	nonisolated(unsafe) private static var inFlight = 0
+	nonisolated(unsafe) private static var peakInFlight = 0
+	/// Held open per request, to make overlap observable.
+	nonisolated(unsafe) private static var responseDelay: Duration = .zero
 	private static let lock = NSLock()
 
-	static func reset(with responses: [Response]) {
+	static func reset(with responses: [Response], responseDelay: Duration = .zero) {
 		lock.lock()
 		defer { lock.unlock() }
 		queue = responses
 		recordedRequests = 0
+		inFlight = 0
+		peakInFlight = 0
+		Self.responseDelay = responseDelay
 	}
 
 	static var requestCount: Int {
 		lock.lock()
 		defer { lock.unlock() }
 		return recordedRequests
+	}
+
+	/// The most requests that were ever being served at the same moment.
+	static var peakConcurrentRequests: Int {
+		lock.lock()
+		defer { lock.unlock() }
+		return peakInFlight
+	}
+
+	private static func beginRequest() -> Duration {
+		lock.lock()
+		defer { lock.unlock() }
+		inFlight += 1
+		peakInFlight = max(peakInFlight, inFlight)
+		return responseDelay
+	}
+
+	private static func endRequest() {
+		lock.lock()
+		defer { lock.unlock() }
+		inFlight -= 1
 	}
 
 	private static func nextResponse() -> Response {
@@ -50,6 +78,9 @@ final class StubURLProtocol: URLProtocol, @unchecked Sendable {
 	static func makeSession() -> URLSession {
 		let configuration = URLSessionConfiguration.ephemeral
 		configuration.protocolClasses = [StubURLProtocol.self]
+		// URLSession would otherwise cap connections per host at 6 on its own,
+		// which would mask whether our throttle is the thing doing the limiting.
+		configuration.httpMaximumConnectionsPerHost = 100
 		return URLSession(configuration: configuration)
 	}
 
@@ -58,6 +89,7 @@ final class StubURLProtocol: URLProtocol, @unchecked Sendable {
 	override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
 	override func startLoading() {
+		let delay = Self.beginRequest()
 		let stub = Self.nextResponse()
 		let response = HTTPURLResponse(
 			url: request.url!,
@@ -66,9 +98,22 @@ final class StubURLProtocol: URLProtocol, @unchecked Sendable {
 			headerFields: ["Content-Type": "text/html"]
 		)!
 
-		client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-		client?.urlProtocol(self, didLoad: stub.body)
-		client?.urlProtocolDidFinishLoading(self)
+		let finish = {
+			self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+			self.client?.urlProtocol(self, didLoad: stub.body)
+			self.client?.urlProtocolDidFinishLoading(self)
+			Self.endRequest()
+		}
+
+		guard delay > .zero else {
+			finish()
+			return
+		}
+
+		Task {
+			try? await Task.sleep(for: delay)
+			finish()
+		}
 	}
 
 	override func stopLoading() {}


### PR DESCRIPTION
Stacked on #6 — **review that one first**; this PR targets its branch, so the diff here is only the follow-up work.

## SwiftText: 1.2.0, not 2.x

Updated to **1.2.0**, which needed no code changes (it also pulls in XMLKit 1.0.1).

2.x does not resolve. Both 2.0.0 and 2.1.0 depend on ZIPFoundation 0.9.x, and SwiftPM refuses a stable-versioned package that depends on an unstable-versioned one:

```
error: Dependencies could not be resolved because package 'swifttext' is required
using a stable-version but 'swifttext' depends on an unstable-version package
'zipfoundation' and root depends on 'swifttext' 2.0.0..<3.0.0.
```

That's an upstream fix — SwiftText needs ZIPFoundation at >= 1.0, or made conditional on a product this package doesn't use. Worth noting 1.1.9 resolved fine with the same ZIPFoundation pin, so something about how it's declared changed in 2.x.

## Robustness

All in the fetch path a set import depends on:

- **Retry with backoff** — 3 attempts, 500 ms doubling, for failures that pass with time: 408, 429, 5xx, an empty body, and the transient `URLError` cases. A 404 or a bot-protection challenge throws immediately; asking again cannot change the answer.
- **Name the challenge** — the WAF interstitial is now `FetchError.blockedByBotProtection` rather than something that fails three layers later as "parts table not found". If BrickLink ever puts the v2 pages behind the challenge too, the failure will say so instead of looking like a parser bug.
- **Empty body is an error**, not empty `Data`. That is the exact shape that used to reach the parser and trap in #6.
- **30 s request timeout** — there was none.
- **Cap requests in flight at 6.** A 619-part inventory previously put a task on the wire for every row at once. `mapConcurrently` keeps a sliding window and preserves input order; rows without their own inventory are built inline, so the window is spent only on rows that actually fetch.

`HTMLFetcher.data` now takes an injectable `URLSession`, which is what makes all of the above testable offline.

## Reviewer notes

**Writing the tests caught a real bug in my first cut of the retry loop.** Retryable `FetchError`s fell through to a `URLError`-only classifier and were never retried — 429 and 503 failed on the first attempt, silently defeating the whole feature. The fix is in `isWorthRetrying`, and `rateLimitIsRetriedUpToTheAttemptLimit` / `transientServerErrorIsRetriedThenSucceeds` now pin it.

**`HTMLFetcherTests` is `@Suite(.serialized)`** because `StubURLProtocol` queues responses in global state. Without it Swift Testing's parallel execution interleaves the tests and they stomp on each other. Worth knowing before adding cases there.

**Retry classification is a judgement call** — I treated an empty body as transient (retryable) and a challenge as permanent (not), based on the probing in #6 where the challenge was identical across sets, parameters, referrers, cookie warm-up and four retries over 30 s. Happy to adjust if you'd rather be more or less patient.

## Testing

- `swift test`: **58 passing**, up from 46.
  - 7 new fetch tests: success, challenge detection, empty body, transient 503 → retry → success, 429 exhausting attempts, 404 not retried, classification table.
  - 5 new concurrency tests: order preservation, window never exceeds the limit, empty input does no work, throwing transform propagates, `limit < 1` behaves serially.
- Verified in the iPad simulator against a **fresh database** (app uninstalled first, so nothing came from cache): 43245-1 imports with the throttled fetcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)